### PR TITLE
Allow CORS and public access for /api/users/register endpoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,4 +22,5 @@ services:
       retries: 5
 
 volumes:
-  cassandra-data: 
+  cassandra-data:
+  # wick_cassandra-data

--- a/src/main/java/com/wick/config/SecurityConfig.java
+++ b/src/main/java/com/wick/config/SecurityConfig.java
@@ -32,7 +32,7 @@ public class SecurityConfig {
         http
             .csrf(csrf -> csrf.disable())
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/", "/register", "/login", "/css/**", "/js/**", "/webjars/**").permitAll()
+                .requestMatchers("/api/users/register", "/", "/register", "/login", "/css/**", "/js/**", "/webjars/**").permitAll()
                 .anyRequest().authenticated()
             )
             .formLogin(form -> form

--- a/src/main/java/com/wick/config/WebConfig.java
+++ b/src/main/java/com/wick/config/WebConfig.java
@@ -1,0 +1,23 @@
+package com.wick.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.lang.NonNull;
+
+@Configuration
+public class WebConfig {
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(@NonNull CorsRegistry registry) {
+                registry.addMapping("/api/**")
+                        .allowedOrigins("http://localhost:3000")
+                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                        .allowedHeaders("*");
+            }
+        };
+    }
+} 


### PR DESCRIPTION
fix: allow CORS and public access for /api/users/register endpoint

- Added global CORS configuration to allow requests from http://localhost:3000
- Updated security config to permit all requests to /api/users/register for registration and preflight requests